### PR TITLE
Fix typos and improve clarity in documentation files

### DIFF
--- a/docs/Archive/get-started-with-the-react-sdk-copyyy/react-sdk-register-an-nft-as-an-ip-asset.md
+++ b/docs/Archive/get-started-with-the-react-sdk-copyyy/react-sdk-register-an-nft-as-an-ip-asset.md
@@ -19,7 +19,7 @@ This section demonstrates how to register an IP asset using the React SDK. There
 1. Register an existing NFT as an IP asset
 2. Create an NFT and register it as an IP asset in one transaction
 
-For this section, we will register an existing NFT as a IP asset (#1 above).
+For this section, we will register an existing NFT as an IP asset (#1 above).
 
 ## Prerequisites
 

--- a/docs/Concepts/dispute-module/uma-arbitration-policy.md
+++ b/docs/Concepts/dispute-module/uma-arbitration-policy.md
@@ -131,4 +131,4 @@ Depending on what the type of the Dispute Tag is, you also need to include extra
 
 > 📘 Note
 >
-> As the process is still experimental, we can expect iteration and fine tuning on the contents/formats of how the evidence should be submitted.
+> As the process is still experimental, we can expect iteration and fine-tuning on the contents/formats of how the evidence should be submitted.

--- a/docs/Concepts/programmable-ip-license/index.md
+++ b/docs/Concepts/programmable-ip-license/index.md
@@ -24,7 +24,7 @@ next:
 
 > 📘 PIL Legal Text
 >
-> Check out the actual PIL legal text [here](https://github.com/storyprotocol/protocol-core-v1/blob/main/PIL_Testnet.pdf). It is very human readable for a legal text!
+> Check out the actual PIL legal text [here](https://github.com/storyprotocol/protocol-core-v1/blob/main/PIL_Testnet.pdf). It is very human-readable for a legal text!
 
 ## The Background Story
 

--- a/docs/Smart Contract Reference/beta-registries/metadata/metadataproviderbasesol.md
+++ b/docs/Smart Contract Reference/beta-registries/metadata/metadataproviderbasesol.md
@@ -76,7 +76,7 @@ Gets the metadata associated with an IP Asset.
 function setUpgradeProvider(address provider) external
 ```
 
-Sets a upgrade provider for users to migrate their metadata to.
+Sets an upgrade provider for users to migrate their metadata to.
 
 #### Parameters
 


### PR DESCRIPTION
This pull request addresses several typos and grammatical improvements across the following files:
- `react-sdk-register-an-nft-as-an-ip-asset.md`
- `uma-arbitration-policy.md`
- `index.md`
- `metadataproviderbasesol.md`

Changes include:
- Correcting article usage and hyphenation (e.g., "a IP" → "an IP").
- Fixing missing hyphens in compound adjectives (e.g., "fine tuning" → "fine-tuning").
- Improving readability in several sentences.
