### PR TITLE
Fix syntactic error in the configuration key name

### DIFF
--- a/docs/Story Network (L1)/story-network/odyssey-node-setup.md
+++ b/docs/Story Network (L1)/story-network/odyssey-node-setup.md
@@ -288,7 +288,7 @@ If you would like to check the status of `story` while it is running, it is help
 ### Common Issues
 
 1. `auth failure: secret conn failed: read tcp ${IP_A}:${PORT_A}->${IP_B}:{PORT_B}: i/o timeout`
-   * This issue occurs when the default `external_address` listed in `config.toml` (`””`) is not being introspected properly via the listener. To fix it, please remove `addrbook.json` in `{STORY_DATA_ROOT}/config/addrbook.json` and add `exteral_address = {YOUR_NODE_PUBLIC_IP_ADDRESS}` in `config.toml`
+   * This issue occurs when the default `external_address` listed in `config.toml` (`””`) is not being introspected properly via the listener. To fix it, please remove `addrbook.json` in `{STORY_DATA_ROOT}/config/addrbook.json` and add `external_address = {YOUR_NODE_PUBLIC_IP_ADDRESS}` in `config.toml`
 
 ### Automated Upgrades
 


### PR DESCRIPTION
In the configuration file, the parameter should be named external_address. A typo (exteral_address) will cause the client to not recognize the setting, and the node may experience problems establishing a proper P2P connection.