### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/Concepts/royalty-module/external-royalty-policies.md
+++ b/docs/Concepts/royalty-module/external-royalty-policies.md
@@ -62,7 +62,7 @@ is called on the "Policy X" address. It should return the % of derivative's roya
 There are two ways in which an External Royalty Policy can redistribute value back to its users:
 
 1. Send Royalty Tokens directly to its users
-2. Keep the Royalty Tokens in the External Royalty Policy contract and have users claim Revenue Tokens through the the said contract
+2. Keep the Royalty Tokens in the External Royalty Policy contract and have users claim Revenue Tokens through the said contract
 
 Let's explore both in the context of "Policy X". Let's say that from the 50% of RT3 token supply "Policy X" received - 40% are kept in the "Policy X" contract and 10% are sent to an ancestor royalty vault (IP1).
 

--- a/docs/Concepts/story-modules/hooks.md
+++ b/docs/Concepts/story-modules/hooks.md
@@ -36,7 +36,7 @@ import { IHookModule } from "../../../contracts/interfaces/modules/base/IHookMod
 import { BaseModule } from "../../../contracts/modules/BaseModule.sol";
 
 /// @title Token Gated Hook.
-/// @notice Hook for ensursing caller is the owner of an NFT token.
+/// @notice Hook for ensuring caller is the owner of an NFT token.
 contract TokenGatedHook is BaseModule, IHookModule {
     using ERC165Checker for address;
 

--- a/docs/Concepts/story-modules/how-to-create-and-register-modules.md
+++ b/docs/Concepts/story-modules/how-to-create-and-register-modules.md
@@ -29,7 +29,7 @@ import { IHookModule } from "contracts/interfaces/modules/base/IHookModule.sol";
 import { BaseModule } from "contracts/modules/BaseModule.sol";
 
 /// @title Mock Token Gated Hook.
-/// @notice Hook for ensursing caller is the owner of an NFT token.
+/// @notice Hook for ensuring caller is the owner of an NFT token.
 contract TokenGatedHook is BaseModule, IHookModule {
     using ERC165Checker for address;
 

--- a/docs/Story Network (L1)/story-network/tokenomics-staking.md
+++ b/docs/Story Network (L1)/story-network/tokenomics-staking.md
@@ -315,7 +315,7 @@ The UBI contract address: **0xcccccc0000000000000000000000000000000002**
 
 The first 403,200 blocks after the genesis is called Singularity, during which everyone can create a validator and stake tokens but the active validator set will only have the genesis validators. There is also no new token emission, hence no reward. Unstake and redelegate are also not supported.
 
-The Genesis validator set consists of 8 validators, setup by the foundation and trusted staking institutions. 4 of them support locked tokens and the other 4 support unlocked tokens. Each of them has an initial stake of 0.001 IP. Each of them will have a default 7% commission rate. During the Singularity, the genesis valdiators will need to self delegate at least 1024 IP to perform validator operations like editing validator commission rate.
+The Genesis validator set consists of 8 validators, setup by the foundation and trusted staking institutions. 4 of them support locked tokens and the other 4 support unlocked tokens. Each of them has an initial stake of 0.001 IP. Each of them will have a default 7% commission rate. During the Singularity, the genesis validators will need to self delegate at least 1024 IP to perform validator operations like editing validator commission rate.
 
 After Singularity, the top 112 validator nodes with the highest stakes will be selected to participate in consensus and receive rewards.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `through the the said` to `through the said`
Corrected `ensursing` to `ensuring` x2
Corrected `valdiators` to `validators`

Please review the changes and let me know if any additional changes are needed.

