### PR TITLE
fix: correct grammar, punctuation, and update Twitter URL

### DIFF
--- a/combined.md
+++ b/combined.md
@@ -3079,7 +3079,7 @@ contract MockRegistry {
 # ⚙️ IP Account
 > 🐦 Skip the Read
 >
-> Get a quick 2-minute overview of IP Accounts [here](https://twitter.com/jacobmtucker/status/1787603252198134234).
+> Get a quick 2-minute overview of IP Accounts [here](https://x.com/jacobmtucker/status/1787603252198134234).
 
 When an [🧩 IP Asset](doc:ip-asset) is registered, it is given an associated **IP Account**. An IP Account is a modified ERC-6551 (Token Bound Account) implementation. It is a separate contract bound to the IP Asset for controlling permissions around interactions with Story's modules or storing the IP's associated data. Upon registration, an IP Asset is assigned a unique ID. This ID is the address of the IP Account that is bound to the IP Asset.
 
@@ -3528,7 +3528,7 @@ The different relationship types that can be used for the `relationships` attrib
       socialMedia: [
         {
           platform: "Twitter",
-          url: "https://twitter.com/kentathesamurai"
+          url: "https://x.com/kentathesamurai"
         }
       ]
     },
@@ -3624,7 +3624,7 @@ The different relationship types that can be used for the `relationships` attrib
 # 🧩 IP Asset
 > 🐦 Skip the Read
 >
-> Get a quick 1-minute overview of IP Assets [here](https://twitter.com/jacobmtucker/status/1785765362744889410).
+> Get a quick 1-minute overview of IP Assets [here](https://x.com/jacobmtucker/status/1785765362744889410).
 
 IP Assets are the foundational programmable IP metadata on Story. Each IP Asset is an on-chain ERC-721 NFT (representing an IP). Yes, that means your Azuki or Pudgy Penguin is already eligible for registration into our protocol, and don't worry, there is no wrapping involved.
 
@@ -15789,7 +15789,7 @@ Story tokenizes any type of IP; whether that’s an idea, an image, a real world
 
 When IP owners share their work online, it’s easy for others to use or change it without crediting them, and they often don't get paid fairly if their work becomes popular or valuable. This can be discouraging for people who want to share their ideas and creations but don’t want to lose control over them.
 
-Additionally, the sheer speed and superabundance of AI-generated media is outpacing the current IP system that was designed for physical replication. In many cases, [AI is trained on and is producing copyrighted data](https://twitter.com/BriannaWu/status/1823833723764084846).
+Additionally, the sheer speed and superabundance of AI-generated media is outpacing the current IP system that was designed for physical replication. In many cases, [AI is trained on and is producing copyrighted data](https://x.com/BriannaWu/status/1823833723764084846).
 
 Story fixes this by providing a way for creators to share their work with built-in protection. When someone (including an AI model) uses a song, image, or any creative work that’s registered on Story, the system automatically tracks who the original owner is and makes sure they get credited. Plus, if that work generates revenue—say someone remixes a song and it earns money—the original owner automatically receives their fair share based on license terms that were set on-chain.
 

--- a/docs/Concepts/ip-account.md
+++ b/docs/Concepts/ip-account.md
@@ -12,7 +12,7 @@ next:
 ---
 > 🐦 Skip the Read
 >
-> Get a quick 2-minute overview of IP Accounts [here](https://twitter.com/jacobmtucker/status/1787603252198134234).
+> Get a quick 2-minute overview of IP Accounts [here](https://x.com/jacobmtucker/status/1787603252198134234).
 
 When an [🧩 IP Asset](doc:ip-asset) is registered, it is given an associated **IP Account**. An IP Account is a modified ERC-6551 (Token Bound Account) implementation. It is a separate contract bound to the IP Asset for controlling permissions around interactions with Story's modules or storing the IP's associated data. Upon registration, an IP Asset is assigned a unique ID. This ID is the address of the IP Account that is bound to the IP Asset.
 

--- a/docs/Concepts/ip-asset/index.md
+++ b/docs/Concepts/ip-asset/index.md
@@ -12,7 +12,7 @@ next:
 ---
 > 🐦 Skip the Read
 >
-> Get a quick 1-minute overview of IP Assets [here](https://twitter.com/jacobmtucker/status/1785765362744889410).
+> Get a quick 1-minute overview of IP Assets [here](https://x.com/jacobmtucker/status/1785765362744889410).
 
 IP Assets are the foundational programmable IP metadata on Story. Each IP Asset is an on-chain ERC-721 NFT (representing an IP). Yes, that means your Azuki or Pudgy Penguin is already eligible for registration into our protocol, and don't worry, there is no wrapping involved.
 

--- a/docs/Concepts/ip-asset/ipa-metadata-standard.md
+++ b/docs/Concepts/ip-asset/ipa-metadata-standard.md
@@ -438,7 +438,7 @@ The different relationship types that can be used for the `relationships` attrib
       socialMedia: [
         {
           platform: "Twitter",
-          url: "https://twitter.com/kentathesamurai"
+          url: "https://x.com/kentathesamurai"
         }
       ]
     },

--- a/docs/Introduction/faq.md
+++ b/docs/Introduction/faq.md
@@ -36,9 +36,9 @@ With Story, Azuki & Pudgy holders can register their IP as **IP Assets** and the
 
 ## *"What are the challenges?"*
 
-The natural question arises: "*What if I'm a bad actor and I ignore all of this and just Right Click Save As?*"
+The natural question arises: "*What if I'm a bad actor and I ignore all of this and just Right-Click Save As?*"
 
-First, its underestimated the extent to which people want to follow the law. This is why PIL is so important - all of the\
+First, it's underestimated the extent to which people want to follow the law. This is why PIL is so important - all of the\
 IP is not just on-chain, it is tied to a real legal contract! If people rip off your IP, they can be sued in court. However this "happy path" doesn't always happen. When things go wrong, we want to provide as many layers of escalation before resorting to off-chain arbitration.
 
 Thus, we've created the [Dispute Module](doc:dispute-module) that allows anyone to flag violating content on-chain. If the dispute is\
@@ -93,6 +93,6 @@ Similarly, the dispute module can check if an IP has been flagged due to its anc
 
 We will support a few ways, including the [Dispute Module](doc:dispute-module), to deter IP infringement. For example if someone were to register someone else's IP, it could be disputed on-chain. And in the worst case, it would be brought to court just as it works in the traditional legal system today.
 
-A more nuanced answer to this (one that we're constantly exploring/improving upon) is there may be additional ways to deter IP infringement. For example, a staking validation mechanism where users could stake tokens on a piece of IP being valid, and if it were to be disputed and marked as copyright, the tokens get slashed and distributed to the creator who was harmed. Additionally we've thought of introducing external IP infringement detection services directly into our L1 at the lowest level that could flag or automatically mark IP as potential infringement the moment its registered.
+A more nuanced answer to this (one that we're constantly exploring/improving upon) is there may be additional ways to deter IP infringement. For example, a staking validation mechanism where users could stake tokens on a piece of IP being valid, and if it were to be disputed and marked as copyright, the tokens get slashed and distributed to the creator who was harmed. Additionally we've thought of introducing external IP infringement detection services directly into our L1 at the lowest level that could flag or automatically mark IP as potential infringement the moment it's registered
 
 Ultimately Story is not a system built to prevent bad actors, rather it is meant to help facilitate honest actors to more easily register their IP, remix from others, and set proper terms for their work. The protocol is permissionless and stopping bad actors entirely would be near impossible, but we can try to disincentivize them as best we can. Much like how the pirating of media plummeted when Apple Music, Spotify, and Netflix made such media more accessible by creating a "path of least resistance", we see a similar future with Story & IP.

--- a/docs/Introduction/quickstart.md
+++ b/docs/Introduction/quickstart.md
@@ -47,7 +47,7 @@ Let's start with the most basic question: *"What does it take to register IP on 
 
 To register IP on Story, you'll first need an NFT. If your IP is an ERC-721 NFT (ex. an Azuki or Pudgy Penguin on Story), you're already set. If not, you must mint an NFT to represent your off-chain IP. And don't worry, we'll help you do this in the following tutorials.
 
-Next you'd register that NFT on Story, ultimately creating an [🧩 IP Asset](doc:ip-asset). An "IP Asset" is your IP registered on Story, empowered by:
+Next, you'd register that NFT on Story, ultimately creating an [🧩 IP Asset](doc:ip-asset). An "IP Asset" is your IP registered on Story, empowered by:
 
 * all of Story's [🧱 Modules](doc:story-modules) like transparent licensing, automatic royalty payments, and disputing of wrongfully registered IP
 * IP protection through the [💊 Programmable IP License (PIL)](doc:programmable-ip-license)
@@ -66,7 +66,7 @@ To answer that question, please see [NFT vs. IP Metadata](https://docs.story.fou
 
 You may be wondering, *"How do I take advantage of Story's on-chain licensing? How do I make sure my registered IP has a license ready to go?"*
 
-Before you attach any sort of licenses or license terms to your [🧩 IP Asset](doc:ip-asset), it would be best to first understand what the [💊 Programmable IP License (PIL)](doc:programmable-ip-license) actually is. This "PIL" is what defines the available [License Terms](doc:license-terms) on Story, which in turn - when attached to an IP Asset - is what defines how others can use (commercially, create derivatives, etc) that IP Asset.
+Before you attach any licenses or license terms to your [🧩 IP Asset](doc:ip-asset), it would be best to first understand what the [💊 Programmable IP License (PIL)](doc:programmable-ip-license) actually is. This "PIL" is what defines the available [License Terms](doc:license-terms) on Story, which, in turn, when attached to an IP Asset, defines how others can use (commercially, create derivatives, etc) that IP Asset.
 
 Our SDK tutorial will show you exactly how to attach license terms to your IP Asset:
 
@@ -117,7 +117,7 @@ Let's start with the most basic question: *"What does it take to register IP on 
 
 To register IP on Story, you'll first need an NFT. If your IP is an ERC-721 NFT (ex. an Azuki or Pudgy Penguin on Story), you're already set. If not, you must mint an NFT to represent your off-chain IP. And don't worry, we'll help you do this in the following tutorial.
 
-Next you'd register that NFT on Story, ultimately creating an [🧩 IP Asset](doc:ip-asset). An "IP Asset" is your IP registered on Story, empowered by:
+Next, you'd register that NFT on Story, ultimately creating an [🧩 IP Asset](doc:ip-asset). An "IP Asset" is your IP registered on Story, empowered by:
 
 * all of Story's [🧱 Modules](doc:story-modules) like transparent licensing, automatic royalty payments, and disputing of wrongfully registered IP
 * IP protection through the [💊 Programmable IP License (PIL)](doc:programmable-ip-license)
@@ -136,7 +136,7 @@ To answer that question, please see [NFT vs. IP Metadata](https://docs.story.fou
 
 You may be wondering, *"How do I take advantage of Story's on-chain licensing? How do I make sure my registered IP has a license ready to go?"*
 
-Before you attach any sort of licenses or license terms to your [🧩 IP Asset](doc:ip-asset), it would be best to first understand what the [💊 Programmable IP License (PIL)](doc:programmable-ip-license) actually is. This "PIL" is what defines the available [License Terms](doc:license-terms) on Story, which in turn - when attached to an IP Asset - is what defines how others can use (commercially, create derivatives, etc) that IP Asset.
+Before you attach any licenses or license terms to your [🧩 IP Asset](doc:ip-asset), it would be best to first understand what the [💊 Programmable IP License (PIL)](doc:programmable-ip-license) actually is. This "PIL" is what defines the available [License Terms](doc:license-terms) on Story, which, in turn, when attached to an IP Asset, defines how others can use (commercially, create derivatives, etc) that IP Asset.
 
 Our smart contract tutorial will show you exactly how to attach license terms to your IP Asset:
 

--- a/docs/Introduction/what-is-story.md
+++ b/docs/Introduction/what-is-story.md
@@ -31,7 +31,7 @@ Story tokenizes any type of IP; whether that’s an idea, an image, a real world
 
 When IP owners share their work online, it’s easy for others to use or change it without crediting them, and they often don't get paid fairly if their work becomes popular or valuable. This can be discouraging for people who want to share their ideas and creations but don’t want to lose control over them.
 
-Additionally, the sheer speed and superabundance of AI-generated media is outpacing the current IP system that was designed for physical replication. In many cases, [AI is trained on and is producing copyrighted data](https://twitter.com/BriannaWu/status/1823833723764084846).
+Additionally, the sheer speed and superabundance of AI-generated media is outpacing the current IP system that was designed for physical replication. In many cases, [AI is trained on and is producing copyrighted data](https://x.com/BriannaWu/status/1823833723764084846).
 
 Story fixes this by providing a way for creators to share their work with built-in protection. When someone (including an AI model) uses a song, image, or any creative work that’s registered on Story, the system automatically tracks who the original owner is and makes sure they get credited. Plus, if that work generates revenue—say someone remixes a song and it earns money—the original owner automatically receives their fair share based on license terms that were set on-chain.
 


### PR DESCRIPTION
fix: correct grammar, punctuation, and update Twitter URL

- Fixed incorrect contractions:
  - "its underestimated" → "it's underestimated"
  - "potential infringement the moment its registered." → "potential infringement the moment it's registered."
- Improved punctuation and formatting:
  - "Right Click Save As" → "Right-Click Save As" (added hyphen)
  - "Next you'd register that NFT on Story" → "Next, you'd register that NFT on Story" (added missing comma)
  - "which in turn - when attached to an IP Asset - is what defines how others can use" → "which, in turn, when attached to an IP Asset, defines how others can use" (replaced incorrect dashes with commas)
- Simplified wording:
  - "Before you attach any sort of licenses or license terms" → "Before you attach any licenses or license terms" (removed unnecessary phrase)
- **Updated Twitter URL:**  
  - Replaced outdated `twitter.com` link with `x.com` to align with platform rebranding.

Happy to continue improving the documentation!
