### PR TITLE
Fix Links

### DIFF
--- a/combined.md
+++ b/combined.md
@@ -7783,7 +7783,7 @@ story_client = StoryClient(web3, account, 1516)
 ```
 
 # SPG Functions
-A group of functions provided by the [Story Protocol Gateway (SPG) contract](https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/StoryProtocolGateway.sol), which is essentially a way to combine independent operations like [Register an NFT as an IP Asset](doc:register-an-nft-as-an-ip-asset-python) and [Attach License Terms to an IP Asset](doc:attach-license-terms-to-an-ip-asset-python) into one transaction to make your life easier.
+A group of functions provided by the [Story Protocol Gateway (SPG) contract](https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/SPGNFT.sol), which is essentially a way to combine independent operations like [Register an NFT as an IP Asset](doc:register-an-nft-as-an-ip-asset-python) and [Attach License Terms to an IP Asset](doc:attach-license-terms-to-an-ip-asset-python) into one transaction to make your life easier.
 
 > 🚧 Warning!
 >
@@ -8956,7 +8956,7 @@ This function allows you to do all of the following: Mint an NFT :arrow_forward:
 >
 > The address of `nftContract` **must** implement <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/interfaces/ISPGNFT.sol" target="_blank">ISPGNFT</a> in order to work.
 >
-> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/StoryProtocolGateway.sol" target="_blank">SPG contract</a>.
+> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/SPGNFT.sol" target="_blank">SPG contract</a>.
 
 > 📘 NFT Metadata
 >
@@ -9172,7 +9172,7 @@ This function allows you to do all of the following: Mint an NFT :arrow_forward:
 >
 > The address of `nftContract` **must** implement <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/interfaces/ISPGNFT.sol" target="_blank">ISPGNFT</a> in order to work.
 >
-> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/StoryProtocolGateway.sol" target="_blank">SPG contract</a>.
+> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/SPGNFT.sol" target="_blank">SPG contract</a>.
 
 > 📘 NFT Metadata
 >
@@ -15446,7 +15446,7 @@ This function allows you to do all of the following: Mint an NFT :arrow_forward:
 >
 > The address of `nftContract` **must** implement <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/interfaces/ISPGNFT.sol" target="_blank">ISPGNFT</a> in order to work.
 >
-> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/StoryProtocolGateway.sol" target="_blank">SPG contract</a>.
+> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/SPGNFT.sol" target="_blank">SPG contract</a>.
 
 > 📘 NFT Metadata
 >

--- a/docs/Developers/python-sdk/spg-functions-python.md
+++ b/docs/Developers/python-sdk/spg-functions-python.md
@@ -10,7 +10,7 @@ metadata:
 next:
   description: ''
 ---
-A group of functions provided by the [Story Protocol Gateway (SPG) contract](https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/StoryProtocolGateway.sol), which is essentially a way to combine independent operations like [Register an NFT as an IP Asset](doc:register-an-nft-as-an-ip-asset-python) and [Attach License Terms to an IP Asset](doc:attach-license-terms-to-an-ip-asset-python) into one transaction to make your life easier.
+A group of functions provided by the [Story Protocol Gateway (SPG) contract](https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/SPGNFT.sol), which is essentially a way to combine independent operations like [Register an NFT as an IP Asset](doc:register-an-nft-as-an-ip-asset-python) and [Attach License Terms to an IP Asset](doc:attach-license-terms-to-an-ip-asset-python) into one transaction to make your life easier.
 
 > 🚧 Warning!
 >

--- a/docs/Developers/react-sdk/spg-functions-react.md
+++ b/docs/Developers/react-sdk/spg-functions-react.md
@@ -24,7 +24,7 @@ This function allows you to do all of the following: Mint an NFT :arrow_forward:
 >
 > The address of `nftContract` **must** implement <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/interfaces/ISPGNFT.sol" target="_blank">ISPGNFT</a> in order to work.
 >
-> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/StoryProtocolGateway.sol" target="_blank">SPG contract</a>.
+> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/SPGNFT.sol" target="_blank">SPG contract</a>.
 
 > 📘 NFT Metadata
 >
@@ -240,7 +240,7 @@ This function allows you to do all of the following: Mint an NFT :arrow_forward:
 >
 > The address of `nftContract` **must** implement <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/interfaces/ISPGNFT.sol" target="_blank">ISPGNFT</a> in order to work.
 >
-> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/StoryProtocolGateway.sol" target="_blank">SPG contract</a>.
+> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/SPGNFT.sol" target="_blank">SPG contract</a>.
 
 > 📘 NFT Metadata
 >

--- a/docs/Developers/typescript-sdk/register-a-derivative.md
+++ b/docs/Developers/typescript-sdk/register-a-derivative.md
@@ -208,7 +208,7 @@ This function allows you to do all of the following: Mint an NFT :arrow_forward:
 >
 > The address of `nftContract` **must** implement <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/interfaces/ISPGNFT.sol" target="_blank">ISPGNFT</a> in order to work.
 >
-> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/StoryProtocolGateway.sol" target="_blank">SPG contract</a>.
+> An easy way to create a collection that implements ISPGNFT is to call the `createCollection` function in the <a href="https://github.com/storyprotocol/protocol-periphery-v1/blob/main/contracts/SPGNFT.sol" target="_blank">SPG contract</a>.
 
 > 📘 NFT Metadata
 >

--- a/docs/Developers/typescript-sdk/register-pil-terms.md
+++ b/docs/Developers/typescript-sdk/register-pil-terms.md
@@ -15,7 +15,7 @@ This section demonstrates how to register a selection of License Terms using the
 ## Prerequisites
 
 * [Setup](doc:typescript-sdk-setup) the client object.
-* If License Terms already exist for the identical set of parameters you intend to create, it is unnecessary to create it again and the function will simply return the existing `licenseTermsId` and an undefined `txHash`. You can use existing License Terms by its `licenseTermsId`. 
+* If License Terms already exist for the identical set of parameters you intend to create, it is unnecessary to create it again and the function will simply return the existing `licenseTermsId` and an undefined `txHash`. You can use existing License Terms by their `licenseTermsId`. 
 
 > 🪙 Whitelisted Revenue Tokens
 >


### PR DESCRIPTION
Correction of Link: The link to the SPG contract was updated from StoryProtocolGateway.sol to SPGNFT.sol. This change is necessary to ensure that users are directed to the correct contract documentation, which is crucial for understanding the functionalities provided by the Story Protocol Gateway. Accurate documentation links enhance the user experience and prevent confusion.