### PR TITLE
fix(docs): fix broken links

### DIFF
--- a/docs/Developers/typescript-sdk/typescript-sdk-setup/index.md
+++ b/docs/Developers/typescript-sdk/typescript-sdk-setup/index.md
@@ -47,7 +47,7 @@ Before continuing with the code below:
 
 1. Make sure to have `WALLET_PRIVATE_KEY` set up in your `.env` file.
 2. Make sure to have `RPC_PROVIDER_URL` set up in your `.env` file.
-   1. You can use the public default one (`https://aeneid.storyrpc.io`) or check out the other RPCs [here](https://docs.story.foundation/docs/story-network#-rpcs).
+   1. You can use the public default one (`https://aeneid.storyrpc.io`) or check out the other RPCs [here](https://docs.story.foundation/docs/network-info#-rpcs).
 
 ```typescript index.ts
 import { http } from 'viem';

--- a/docs/Developers/typescript-sdk/typescript-sdk-setup/rainbowkit-setup.md
+++ b/docs/Developers/typescript-sdk/typescript-sdk-setup/rainbowkit-setup.md
@@ -27,7 +27,7 @@ yarn add @story-protocol/core-sdk viem
 Before diving into the example, make sure you have two things setup:
 
 1. Make sure to have `NEXT_PUBLIC_RPC_PROVIDER_URL` set up in your `.env` file.
-   1. You can use the public default one (`https://rpc.odyssey.storyrpc.io`) or any other RPC [here](https://docs.story.foundation/docs/story-network#-rpcs).
+   1. You can use the public default one (`https://rpc.odyssey.storyrpc.io`) or any other RPC [here](https://docs.story.foundation/docs/network-info#-rpcs).
 2. Make sure to have `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` set up in your `.env` file. Do this by logging into [Reown (prev. WalletConnect)](https://reown.com/) and creating a project.
 
 ```jsx Web3Providers.tsx

--- a/docs/Developers/typescript-sdk/typescript-sdk-setup/tomo-setup.md
+++ b/docs/Developers/typescript-sdk/typescript-sdk-setup/tomo-setup.md
@@ -27,7 +27,7 @@ yarn add @story-protocol/core-sdk viem
 Before diving into the example, make sure you have two things setup:
 
 1. Make sure to have `NEXT_PUBLIC_RPC_PROVIDER_URL` set up in your `.env` file.
-   1. You can use the public default one (`https://rpc.odyssey.storyrpc.io`) or any other RPC [here](https://docs.story.foundation/docs/story-network#-rpcs).
+   1. You can use the public default one (`https://rpc.odyssey.storyrpc.io`) or any other RPC [here](https://docs.story.foundation/docs/network-info#-rpcs).
 2. Make sure to have `NEXT_PUBLIC_TOMO_CLIENT_ID` set up in your `.env` file. Do this by logging into the [Tomo Dashboard](https://dashboard.tomo.inc/) and creating a project.
 3. Make sure to have `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` set up in your `.env` file. Do this by logging into [Reown (prev. WalletConnect)](https://reown.com/) and creating a project.
 


### PR DESCRIPTION
I have fixed a few links in the `typescript-sdk-setup` docs to point to the correct place for RPCs