### PR TITLE
Update node-setup-mainnet.md

### DIFF
--- a/docs/Story Network (L1)/operating-a-node/node-setup-mainnet.md
+++ b/docs/Story Network (L1)/operating-a-node/node-setup-mainnet.md
@@ -222,6 +222,26 @@ sudo xattr -rd com.apple.quarantine ./geth
 
 ### 2.2 Install Story Consensus Client
 
+#### Install Story Client
+
+```bash
+cd $HOME
+wget https://github.com/piplabs/story/releases/download/v1.0.0/story-linux-amd64
+sudo mv story-linux-amd64 story
+sudo chmod +x story
+sudo mv ./story $HOME/go/bin/
+source $HOME/.bashrc
+story version
+```
+
+> You should expect to see version 1.0.0-stable
+
+(Mac OS X Only) The OS X binaries have yet to be signed by our build process, so you may need to unquarantine them manually:
+
+```bash
+sudo xattr -rd com.apple.quarantine ./story
+```
+
 #### Cosmovisor installation
 
 For updating the story client, we recommend using Cosmovisor.
@@ -250,26 +270,6 @@ echo "export DAEMON_NAME=story" >> $HOME/.bash_profile
 echo "export DAEMON_HOME=$HOME/.story/story" >> $HOME/.bash_profile
 echo "export DAEMON_DATA_BACKUP_DIR=${DAEMON_HOME}/cosmovisor/backup" >> $HOME/.bash_profile
 echo "export DAEMON_ALLOW_DOWNLOAD_BINARIES=false" >> $HOME/.bash_profile
-```
-
-#### Install Story Client
-
-```bash
-cd $HOME
-wget https://github.com/piplabs/story/releases/download/v1.0.0/story-linux-amd64
-sudo mv story-linux-amd64 story
-sudo chmod +x story
-sudo mv ./story $HOME/go/bin/
-source $HOME/.bashrc
-story version
-```
-
-> You should expect to see version 1.0.0-stable
-
-(Mac OS X Only) The OS X binaries have yet to be signed by our build process, so you may need to unquarantine them manually:
-
-```bash
-sudo xattr -rd com.apple.quarantine ./story
 ```
 
 #### Init Story with Cosmovisor


### PR DESCRIPTION
The `Cosmovisor installation` section should be placed after the `Install Story Client section`; otherwise, running cosmovisor version will result in the following error:
```
cosmovisor version: v1.6.0
Error: failed to run version command: current binary is invalid: stat /root/.story/story/cosmovisor/genesis/bin/story: no such file or directory
```