### PR TITLE
Fix command line argument for geth binary in node setup documentation

### DIFF
--- a/combined.md
+++ b/combined.md
@@ -1606,7 +1606,7 @@ sudo xattr -rd com.apple.quarantine ./geth
 
     [Service]
     User=${user}
-    ExecStart=${path_to_geth_binary} --aeneid --syncmode full
+    ExecStart=${path_to_geth_binary} -aeneid --syncmode full
     Restart=on-failure
     RestartSec=3
     LimitNOFILE=4096
@@ -16221,4 +16221,3 @@ Congratulations, you claimed revenue using the [💸 Royalty Module](doc:royalty
 Now what happens if an IP Asset doesn't pay their due share? We can dispute the IP on-chain, which we will cover on the next page.
 
 > 🚧 Coming soon!
-

--- a/docs/Story Network (L1)/operating-a-node/node-setup-mainnet.md
+++ b/docs/Story Network (L1)/operating-a-node/node-setup-mainnet.md
@@ -200,7 +200,7 @@ sudo xattr -rd com.apple.quarantine ./geth
 
     [Service]
     User=${user}
-    ExecStart=${path_to_geth_binary} --aeneid --syncmode full
+    ExecStart=${path_to_geth_binary} -aeneid --syncmode full
     Restart=on-failure
     RestartSec=3
     LimitNOFILE=4096


### PR DESCRIPTION
```shell
$ sudo systemctl status story-geth

*** System restart required ***
Last login: Sat Mar  1 13:48:28 2025 from 202.150.184.24
ubuntu@ip-172-31-44-131:~$ sudo systemctl status story-geth
Warning: The unit file, source configuration file or drop-ins of story-geth.service changed on disk>
○ story-geth.service - Story Geth Client
     Loaded: loaded (/etc/systemd/system/story-geth.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Sat 2025-03-01 13:45:26 UTC; 5min ago
    Process: 55857 ExecStart=-aeneid --syncmode full (code=exited, status=0/SUCCESS)
   Main PID: 55857 (code=exited, status=0/SUCCESS)
        CPU: 931us

Mar 01 13:45:26 ip-172-31-44-131 systemd[1]: Started Story Geth Client.
Mar 01 13:45:26 ip-172-31-44-131 systemd[55857]: story-geth.service: Executable -aeneid missing, sk>
Mar 01 13:45:26 ip-172-31-44-131 systemd[1]: story-geth.service: Deactivated successfully.
lines 1-11/11 (END)
```


Fix the error **Executable -aeneid missing**