### PR TITLE
docs: add OpenChainBench RPC latency benchmark reference

### DIFF
--- a/docs/Story Network (L1)/infrastructure-partners.md
+++ b/docs/Story Network (L1)/infrastructure-partners.md
@@ -125,3 +125,7 @@ metadata:
     The most trusted decentralized custody protocol and collective asset management platform.
   </Card>
 </Cards>
+
+## Live RPC Latency Benchmarks
+
+For live latency comparisons across public Story RPC endpoints, see [OpenChainBench](https://openchainbench.com/benchmarks/story-rpc) — an open benchmark that continuously measures free keyless endpoints so developers can choose the fastest provider for their region.


### PR DESCRIPTION
## What is OpenChainBench?

[OpenChainBench](https://openchainbench.com) is an open, live benchmark that continuously measures latency across free public RPC endpoints for dozens of EVM chains. Results are updated in real time using actual JSON-RPC probe requests.

## Why add this?

The infrastructure-partners page already lists RPC providers for Story. This adds a reference to OpenChainBench where developers can see live latency data across public Story endpoints, helping them pick the fastest provider for their use case.

## Change

Added a "Live RPC Latency Benchmarks" section at the end of the infrastructure partners page.